### PR TITLE
refactor: create v1 directory structure for redfish api versioning

### DIFF
--- a/internal/controller/http/redfish/v1/root.go
+++ b/internal/controller/http/redfish/v1/root.go
@@ -1,0 +1,118 @@
+package redfish
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/device-management-toolkit/console/pkg/logger"
+)
+
+// NewRoutes registers the Redfish Service Root handler.
+// It responds to GET on the group base path (e.g., /redfish/v1).
+func NewRoutes(r *gin.RouterGroup, l logger.Interface) {
+	// Service Root per DMTF Redfish spec. Keep minimal and compliant.
+	handler := func(c *gin.Context) {
+		// Minimal ServiceRoot payload. Additional links can be added later.
+		payload := map[string]any{
+			"@odata.type":    "#ServiceRoot.v1_0_0.ServiceRoot",
+			"@odata.id":      "/redfish/v1/",
+			"Id":             "RootService",
+			"Name":           "Redfish Service Root",
+			"RedfishVersion": "1.0.0",
+			"SessionService": map[string]any{
+				"@odata.id": "/redfish/v1/SessionService",
+			},
+			"Systems": map[string]any{
+				"@odata.id": "/redfish/v1/Systems",
+			},
+			"Links": map[string]any{
+				"Sessions": map[string]any{
+					"@odata.id": "/redfish/v1/SessionService/Sessions",
+				},
+			},
+		}
+
+		c.JSON(http.StatusOK, payload)
+	}
+
+	// Register for both the group root and explicit trailing slash.
+	r.GET("", handler)
+	r.GET("/", handler)
+
+	// $metadata endpoint (minimal OData metadata document)
+	r.GET("/$metadata", func(c *gin.Context) {
+		c.Header("Content-Type", "application/xml; charset=utf-8")
+		c.String(http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+	<edmx:DataServices>
+		<Schema Namespace="Redfish" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+			<EntityType Name="ServiceRoot">
+				<Key><PropertyRef Name="Id"/></Key>
+				<Property Name="Id" Type="Edm.String" Nullable="false"/>
+				<Property Name="Name" Type="Edm.String"/>
+				<Property Name="RedfishVersion" Type="Edm.String"/>
+				<NavigationProperty Name="SessionService" Type="Redfish.SessionService"/>
+				<NavigationProperty Name="Systems" Type="Collection(Redfish.ComputerSystem)"/>
+			</EntityType>
+			<EntityType Name="SessionService">
+				<Key><PropertyRef Name="Id"/></Key>
+				<Property Name="Id" Type="Edm.String" Nullable="false"/>
+				<Property Name="Name" Type="Edm.String"/>
+				<Property Name="ServiceEnabled" Type="Edm.Boolean"/>
+				<Property Name="SessionTimeout" Type="Edm.Int64"/>
+				<NavigationProperty Name="Sessions" Type="Collection(Redfish.Session)"/>
+			</EntityType>
+			<EntityType Name="Session">
+				<Key><PropertyRef Name="Id"/></Key>
+				<Property Name="Id" Type="Edm.String" Nullable="false"/>
+				<Property Name="Name" Type="Edm.String"/>
+				<Property Name="UserName" Type="Edm.String"/>
+			</EntityType>
+			<EntityType Name="ComputerSystem">
+				<Key><PropertyRef Name="Id"/></Key>
+				<Property Name="Id" Type="Edm.String" Nullable="false"/>
+				<Property Name="Name" Type="Edm.String"/>
+				<Property Name="PowerState" Type="Edm.String"/>
+			</EntityType>
+			<EntityContainer Name="Service">
+				<EntitySet Name="ServiceRoot" EntityType="Redfish.ServiceRoot"/>
+				<EntitySet Name="SessionService" EntityType="Redfish.SessionService"/>
+				<EntitySet Name="Sessions" EntityType="Redfish.Session"/>
+				<EntitySet Name="Systems" EntityType="Redfish.ComputerSystem"/>
+			</EntityContainer>
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>`)
+	})
+
+	// SessionService endpoint
+	r.GET("/SessionService", func(c *gin.Context) {
+		payload := map[string]any{
+			"@odata.type":    "#SessionService.v1_0_0.SessionService",
+			"@odata.id":      "/redfish/v1/SessionService",
+			"Id":             "SessionService",
+			"Name":           "Redfish Session Service",
+			"ServiceEnabled": true,
+			"SessionTimeout": 30,
+			"Sessions":       map[string]any{"@odata.id": "/redfish/v1/SessionService/Sessions"},
+		}
+
+		c.JSON(http.StatusOK, payload)
+	})
+
+	// Sessions collection endpoint (read-only, empty list for now)
+	r.GET("/SessionService/Sessions", func(c *gin.Context) {
+		payload := map[string]any{
+			"@odata.type":         "#SessionCollection.SessionCollection",
+			"@odata.id":           "/redfish/v1/SessionService/Sessions",
+			"Name":                "Session Collection",
+			"Members@odata.count": 0,
+			"Members":             []any{},
+		}
+
+		c.JSON(http.StatusOK, payload)
+	})
+
+	l.Info("Registered Redfish Service Root at %s", r.BasePath())
+}

--- a/internal/controller/http/redfish/v1/system.go
+++ b/internal/controller/http/redfish/v1/system.go
@@ -1,0 +1,158 @@
+package redfish
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/device-management-toolkit/console/internal/usecase/devices"
+	"github.com/device-management-toolkit/console/pkg/logger"
+)
+
+// Lint constants
+const (
+	maxSystemsList        = 100
+	powerStateUnknown     = "Unknown"
+	powerStateOn          = "On"
+	powerStateOff         = "Off"
+	resetTypeOn           = "On"
+	resetTypeForceOff     = "ForceOff"
+	resetTypeForceRestart = "ForceRestart"
+	resetTypePowerCycle   = "PowerCycle"
+	actionPowerUp         = 2
+	actionPowerCycle      = 5
+	actionPowerDown       = 8
+	actionReset           = 10
+	// CIM PowerState enum values (Device.PowerState)
+	cimPowerOn      = 2
+	cimPowerSleep   = 3
+	cimPowerStandby = 4
+	cimPowerSoftOff = 7
+	cimPowerHardOff = 8
+)
+
+// NewSystemsRoutes registers minimal Redfish ComputerSystem routes.
+// It exposes:
+// - GET /redfish/v1/Systems
+// - GET /redfish/v1/Systems/:id
+// - POST /redfish/v1/Systems/:id/Actions/ComputerSystem.Reset
+// The :id is expected to be the device GUID and will be mapped directly to SendPowerAction.
+func NewSystemsRoutes(r *gin.RouterGroup, d devices.Feature, l logger.Interface) {
+	systems := r.Group("/Systems")
+	systems.GET("", getSystemsCollectionHandler(d, l))
+	systems.GET(":id", getSystemInstanceHandler(d, l))
+	systems.POST(":id/Actions/ComputerSystem.Reset", postSystemResetHandler(d, l))
+	l.Info("Registered Redfish Systems routes under %s", r.BasePath()+"/Systems")
+}
+
+func getSystemsCollectionHandler(d devices.Feature, l logger.Interface) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		items, err := d.Get(c.Request.Context(), maxSystemsList, 0, "")
+		if err != nil {
+			l.Error(err, "http - redfish - Systems collection")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
+			return
+		}
+
+		members := make([]any, 0, len(items))
+		for i := range items { // avoid value copy
+			it := &items[i]
+			if it.GUID == "" {
+				continue
+			}
+
+			members = append(members, map[string]any{
+				"@odata.id": "/redfish/v1/Systems/" + it.GUID,
+			})
+		}
+
+		payload := map[string]any{
+			"@odata.type":         "#ComputerSystemCollection.ComputerSystemCollection",
+			"@odata.id":           "/redfish/v1/Systems",
+			"Name":                "Computer System Collection",
+			"Members@odata.count": len(members),
+			"Members":             members,
+		}
+		c.JSON(http.StatusOK, payload)
+	}
+}
+
+func getSystemInstanceHandler(d devices.Feature, l logger.Interface) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		powerState := powerStateUnknown
+
+		if ps, err := d.GetPowerState(c.Request.Context(), id); err != nil {
+			l.Warn("redfish - Systems instance: failed to get power state for %s: %v", id, err)
+		} else {
+			switch ps.PowerState { // CIM PowerState values
+			case actionPowerUp: // 2 (On)
+				powerState = powerStateOn
+			case cimPowerSleep, cimPowerStandby: // Sleep/Standby -> treat as On
+				powerState = powerStateOn
+			case cimPowerSoftOff, cimPowerHardOff: // Soft Off / Hard Off
+				powerState = powerStateOff
+			default:
+				powerState = powerStateUnknown
+			}
+		}
+
+		payload := map[string]any{
+			"@odata.type": "#ComputerSystem.v1_0_0.ComputerSystem",
+			"@odata.id":   "/redfish/v1/Systems/" + id,
+			"Id":          id,
+			"Name":        "Computer System " + id,
+			"PowerState":  powerState,
+			"Actions": map[string]any{
+				"#ComputerSystem.Reset": map[string]any{
+					"target":                            "/redfish/v1/Systems/" + id + "/Actions/ComputerSystem.Reset",
+					"ResetType@Redfish.AllowableValues": []string{resetTypeOn, resetTypeForceOff, resetTypeForceRestart, resetTypePowerCycle},
+				},
+			},
+		}
+		c.JSON(http.StatusOK, payload)
+	}
+}
+
+func postSystemResetHandler(d devices.Feature, l logger.Interface) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+
+		var body struct {
+			ResetType string `json:"ResetType"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+
+			return
+		}
+
+		var action int
+
+		switch body.ResetType {
+		case resetTypeOn:
+			action = actionPowerUp
+		case resetTypeForceOff:
+			action = actionPowerDown
+		case resetTypeForceRestart:
+			action = actionReset
+		case resetTypePowerCycle:
+			action = actionPowerCycle
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported ResetType"})
+
+			return
+		}
+
+		res, err := d.SendPowerAction(c.Request.Context(), id, action)
+		if err != nil {
+			l.Error(err, "http - redfish - ComputerSystem.Reset")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
+			return
+		}
+
+		c.JSON(http.StatusOK, res)
+	}
+}


### PR DESCRIPTION
- Move Redfish implementation files into versioned v1 directory
- Prepare codebase for future API version support
- Maintain existing functionality while enabling version-specific implementations

Files moved:
- internal/controller/http/redfish/v1/root.go (Redfish ServiceRoot)
- internal/controller/http/redfish/v1/system.go (ComputerSystem resource)