### PR TITLE
feat: implement redfish api v1 service root with dmtf compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ __debug_bin*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Ignore build and console files
+app
+
 # Dependency directories (remove the comment below to include it)
 vendor/
 # ...ignore the ui folder

--- a/internal/controller/http/redfish/v1/errors.go
+++ b/internal/controller/http/redfish/v1/errors.go
@@ -1,3 +1,8 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
 // Package v1 implements Redfish API v1 error handling and utilities.
 package v1
 

--- a/internal/controller/http/redfish/v1/errors_test.go
+++ b/internal/controller/http/redfish/v1/errors_test.go
@@ -1,3 +1,9 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package v1 implements Redfish API v1 error handling and utilities.
 package v1
 
 import (

--- a/internal/controller/http/redfish/v1/root.go
+++ b/internal/controller/http/redfish/v1/root.go
@@ -1,50 +1,301 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2025
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package v1 implements Redfish API v1 error handling and utilities.
 package v1
 
 import (
+	"crypto/rand"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/pkg/logger"
 )
 
-// NewRoutes registers the Redfish Service Root handler.
-// It responds to GET on the group base path (e.g., /redfish/v1).
-func NewRoutes(r *gin.RouterGroup, l logger.Interface) {
-	// Service Root per DMTF Redfish spec. Keep minimal and compliant.
-	handler := func(c *gin.Context) {
-		// Minimal ServiceRoot payload. Additional links can be added later.
-		payload := map[string]any{
-			"@odata.type":    "#ServiceRoot.v1_0_0.ServiceRoot",
-			"@odata.id":      "/redfish/v1/",
-			"Id":             "RootService",
-			"Name":           "Redfish Service Root",
-			"RedfishVersion": "1.0.0",
-			"SessionService": map[string]any{
-				"@odata.id": "/redfish/v1/SessionService",
-			},
-			"Systems": map[string]any{
-				"@odata.id": "/redfish/v1/Systems",
-			},
-			"Links": map[string]any{
-				"Sessions": map[string]any{
-					"@odata.id": "/redfish/v1/SessionService/Sessions",
-				},
-			},
-		}
+const (
+	// UUID constants for service UUID generation
+	uuidByteLength       = 16   // Length of UUID byte array
+	uuidVersionFourMask  = 0x40 // Version 4 mask for UUID
+	uuidVariantTenMask   = 0x80 // Variant 10 mask for UUID
+	uuidVersionClearMask = 0x0f // Clear version bits mask
+	uuidVariantClearMask = 0x3f // Clear variant bits mask
+)
 
-		c.JSON(http.StatusOK, payload)
+// generateServiceUUID generates a UUID for the Redfish service root
+func generateServiceUUID() string {
+	// Generate a proper UUID v4 for production use
+	uuid := make([]byte, uuidByteLength)
+
+	_, err := rand.Read(uuid)
+	if err != nil {
+		// Fallback to a static UUID if random generation fails
+		return "550e8400-e29b-41d4-a716-446655440000"
 	}
 
-	// Register for both the group root and explicit trailing slash.
-	r.GET("", handler)
-	r.GET("/", handler)
+	// Set version (4) and variant bits
+	uuid[6] = (uuid[6] & uuidVersionClearMask) | uuidVersionFourMask // Version 4
+	uuid[8] = (uuid[8] & uuidVariantClearMask) | uuidVariantTenMask  // Variant 10
 
-	// $metadata endpoint (minimal OData metadata document)
-	r.GET("/$metadata", func(c *gin.Context) {
-		c.Header("Content-Type", "application/xml; charset=utf-8")
-		c.String(http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?>
-<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:uuidByteLength])
+}
+
+// Future extensibility functions for upstream service health checks
+// These are placeholder functions that could be implemented to check external dependencies
+
+// isDatabaseReachable checks if the database is accessible
+// Returns false if database is unreachable (would trigger 502)
+func isDatabaseReachable() bool {
+	// Example: ping database, check connection pool, etc.
+	// if db.Ping() != nil { return false }
+	return true // Currently always returns true since we use embedded DB
+}
+
+// areSystemsReachable checks if managed systems/devices are accessible
+// Returns false if critical systems are unreachable (would trigger 502)
+func areSystemsReachable() bool {
+	// Example: check connectivity to Intel AMT devices, network accessibility
+	// if !canReachManagedDevices() { return false }
+	return true // Currently always returns true - no external systems required for service root
+}
+
+// isExternalServiceHealthy checks if external dependencies are available
+// Returns false if required external services are down (would trigger 502)
+func isExternalServiceHealthy() bool {
+	// Example: check EA (Engine Activation) service, external APIs, etc.
+	// if !eaService.IsHealthy() { return false }
+	return true // Currently always returns true - service root is self-contained
+}
+
+// Future extensibility functions for temporary service unavailability (503 errors)
+
+// isServiceOverloaded checks if the service is temporarily overloaded
+// Returns true if too many concurrent requests are being processed (would trigger 503)
+func isServiceOverloaded() bool {
+	// Example: check active connection count, request queue depth, CPU/memory usage
+	// if activeConnections > maxConcurrentConnections { return true }
+	// if requestQueueDepth > threshold { return true }
+	return false // Currently always returns false - no overload detection implemented
+}
+
+// isMaintenanceMode checks if the service is in maintenance mode
+// Returns true if planned maintenance is active (would trigger 503)
+func isMaintenanceMode() bool {
+	// Example: check maintenance flag file, config setting, scheduled maintenance window
+	// if maintenanceFlag.Exists() { return true }
+	// if time.Now().In(maintenanceWindow) { return true }
+	return false // Currently always returns false - no maintenance mode implemented
+}
+
+// hasResourceExhaustion checks if system resources are exhausted
+// Returns true if insufficient resources are available (would trigger 503)
+func hasResourceExhaustion() bool {
+	// Example: check memory usage, disk space, file descriptors, database connections
+	// if memoryUsage > criticalThreshold { return true }
+	// if diskSpace < minRequired { return true }
+	// if dbConnPool.Available() == 0 { return true }
+	return false // Currently always returns false - no resource monitoring implemented
+}
+
+// serviceRootHandler handles the main service root endpoint
+func serviceRootHandler(c *gin.Context) {
+	// Set Redfish-compliant headers
+	SetRedfishHeaders(c)
+
+	// Validate Accept header (406 Not Acceptable)
+	acceptHeader := c.GetHeader("Accept")
+	if acceptHeader != "" && acceptHeader != "*/*" && acceptHeader != "application/json" &&
+		!strings.Contains(acceptHeader, "application/json") && !strings.Contains(acceptHeader, "*/*") {
+		NotAcceptableError(c, acceptHeader)
+
+		return
+	}
+
+	// Generate service UUID with error handling
+	serviceUUID := generateServiceUUID()
+	if serviceUUID == "" {
+		// If UUID generation completely fails, this could indicate system issues
+		BadGatewayError(c)
+
+		return
+	}
+
+	// Future extensibility: Health checks for upstream services that could trigger 502 errors
+	if !isDatabaseReachable() {
+		// Database unreachable - service cannot function properly
+		BadGatewayError(c)
+
+		return
+	}
+
+	if !areSystemsReachable() {
+		// Critical managed systems unreachable - service degraded
+		BadGatewayError(c)
+
+		return
+	}
+
+	if !isExternalServiceHealthy() {
+		// External dependencies unavailable - service cannot provide full functionality
+		BadGatewayError(c)
+
+		return
+	}
+
+	// Check for temporary service unavailability conditions (503 errors)
+	if isServiceOverloaded() {
+		// Service is temporarily overloaded - too many concurrent requests
+		ServiceTemporarilyUnavailableError(c)
+
+		return
+	}
+
+	if isMaintenanceMode() {
+		// Service is in maintenance mode - temporarily unavailable
+		ServiceTemporarilyUnavailableError(c)
+
+		return
+	}
+
+	if hasResourceExhaustion() {
+		// Service has insufficient resources - temporarily unavailable
+		ServiceTemporarilyUnavailableError(c)
+
+		return
+	}
+
+	payload := map[string]any{
+		"@odata.type":    "#ServiceRoot.v1_11_0.ServiceRoot",
+		"@odata.id":      "/redfish/v1/",
+		"Id":             "RootService",
+		"Name":           "Redfish Root Service",
+		"RedfishVersion": "1.11.0",
+		"UUID":           serviceUUID,
+		"Systems":        map[string]any{"@odata.id": "/redfish/v1/Systems"},
+		"SessionService": map[string]any{"@odata.id": "/redfish/v1/SessionService"},
+		// Mandatory Links property with Sessions reference
+		"Links": map[string]any{
+			"Sessions": map[string]any{"@odata.id": "/redfish/v1/SessionService/Sessions"},
+		},
+		// Optional but recommended properties (supported in v1_11_0)
+		"Product": "Device Management Toolkit Console",
+		"Vendor":  "Intel Corporation",
+	}
+
+	c.JSON(http.StatusOK, payload)
+}
+
+// registerServiceRootMethodHandlers registers unsupported method handlers for ServiceRoot
+func registerServiceRootMethodHandlers(r *gin.RouterGroup) {
+	r.POST("/", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "POST", "ServiceRoot", "GET")
+	})
+	r.PUT("/", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "PUT", "ServiceRoot", "GET")
+	})
+	r.PATCH("/", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "PATCH", "ServiceRoot", "GET")
+	})
+	r.DELETE("/", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "DELETE", "ServiceRoot", "GET")
+	})
+}
+
+// registerSystemsMethodHandlers registers unsupported method handlers for Systems collection
+func registerSystemsMethodHandlers(r *gin.RouterGroup) {
+	r.POST("/Systems", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "POST", "ComputerSystemCollection", "GET")
+	})
+	r.PUT("/Systems", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "PUT", "ComputerSystemCollection", "GET")
+	})
+	r.PATCH("/Systems", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "PATCH", "ComputerSystemCollection", "GET")
+	})
+	r.DELETE("/Systems", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "DELETE", "ComputerSystemCollection", "GET")
+	})
+}
+
+// registerSessionServiceRoutes registers all SessionService related routes
+func registerSessionServiceRoutes(r *gin.RouterGroup) {
+	// SessionService endpoint
+	r.GET("/SessionService", sessionServiceHandler)
+
+	// Handle unsupported methods on SessionService with proper 405 responses
+	r.POST("/SessionService", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "POST", "SessionService", "GET")
+	})
+	r.PUT("/SessionService", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "PUT", "SessionService", "GET")
+	})
+	r.PATCH("/SessionService", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "PATCH", "SessionService", "GET")
+	})
+	r.DELETE("/SessionService", func(c *gin.Context) {
+		HTTPMethodNotAllowedError(c, "DELETE", "SessionService", "GET")
+	})
+
+	// Sessions collection endpoint (read-only, empty list for now)
+	r.GET("/SessionService/Sessions", sessionsCollectionHandler)
+
+	// Handle unsupported methods on Sessions collection with proper 405 responses
+	r.PUT("/SessionService/Sessions", func(c *gin.Context) {
+		MethodNotAllowedError(c, "retrieve sessions collection", "GET, POST")
+	})
+	r.PATCH("/SessionService/Sessions", func(c *gin.Context) {
+		MethodNotAllowedError(c, "retrieve sessions collection", "GET, POST")
+	})
+	r.DELETE("/SessionService/Sessions", func(c *gin.Context) {
+		MethodNotAllowedError(c, "retrieve sessions collection", "GET, POST")
+	})
+}
+
+// sessionServiceHandler handles SessionService requests
+func sessionServiceHandler(c *gin.Context) {
+	// Set Redfish-compliant headers
+	SetRedfishHeaders(c)
+
+	payload := map[string]any{
+		"@odata.type":    "#SessionService.v1_0_0.SessionService",
+		"@odata.id":      "/redfish/v1/SessionService",
+		"Id":             "SessionService",
+		"Name":           "Redfish Session Service",
+		"ServiceEnabled": true,
+		"SessionTimeout": 30,
+		"Sessions":       map[string]any{"@odata.id": "/redfish/v1/SessionService/Sessions"},
+	}
+
+	c.JSON(http.StatusOK, payload)
+}
+
+// sessionsCollectionHandler handles Sessions collection requests
+func sessionsCollectionHandler(c *gin.Context) {
+	// Set Redfish-compliant headers
+	SetRedfishHeaders(c)
+
+	payload := map[string]any{
+		"@odata.type":         "#SessionCollection.SessionCollection",
+		"@odata.id":           "/redfish/v1/SessionService/Sessions",
+		"Name":                "Session Collection",
+		"Members@odata.count": 0,
+		"Members":             []any{},
+	}
+
+	c.JSON(http.StatusOK, payload)
+}
+
+// metadataHandler handles OData service metadata requests
+func metadataHandler(c *gin.Context) {
+	c.Header("Content-Type", "application/xml")
+	c.String(http.StatusOK, `<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
 	<edmx:DataServices>
 		<Schema Namespace="Redfish" xmlns="http://docs.oasis-open.org/odata/ns/edm">
 			<EntityType Name="ServiceRoot">
@@ -84,35 +335,30 @@ func NewRoutes(r *gin.RouterGroup, l logger.Interface) {
 		</Schema>
 	</edmx:DataServices>
 </edmx:Edmx>`)
-	})
+}
 
-	// SessionService endpoint
-	r.GET("/SessionService", func(c *gin.Context) {
-		payload := map[string]any{
-			"@odata.type":    "#SessionService.v1_0_0.SessionService",
-			"@odata.id":      "/redfish/v1/SessionService",
-			"Id":             "SessionService",
-			"Name":           "Redfish Session Service",
-			"ServiceEnabled": true,
-			"SessionTimeout": 30,
-			"Sessions":       map[string]any{"@odata.id": "/redfish/v1/SessionService/Sessions"},
-		}
+// NewServiceRootRoutes registers Redfish API v1 service root routes
+func NewServiceRootRoutes(r *gin.RouterGroup, cfg *config.Config, l logger.Interface) {
+	// Apply Redfish-compliant recovery middleware for 500 errors
+	r.Use(RedfishRecoveryMiddleware())
 
-		c.JSON(http.StatusOK, payload)
-	})
+	// Apply Redfish-compliant authentication if auth is enabled
+	if !cfg.Disabled {
+		r.Use(RedfishJWTAuthMiddleware(cfg))
+	}
 
-	// Sessions collection endpoint (read-only, empty list for now)
-	r.GET("/SessionService/Sessions", func(c *gin.Context) {
-		payload := map[string]any{
-			"@odata.type":         "#SessionCollection.SessionCollection",
-			"@odata.id":           "/redfish/v1/SessionService/Sessions",
-			"Name":                "Session Collection",
-			"Members@odata.count": 0,
-			"Members":             []any{},
-		}
+	// Redfish Service Root (main entry point)
+	r.GET("/", serviceRootHandler)
 
-		c.JSON(http.StatusOK, payload)
-	})
+	// Register method handlers for unsupported operations
+	registerServiceRootMethodHandlers(r)
+	registerSystemsMethodHandlers(r)
 
-	l.Info("Registered Redfish Service Root at %s", r.BasePath())
+	// Register additional service routes
+	registerSessionServiceRoutes(r)
+
+	// OData Service Document
+	r.GET("/$metadata", metadataHandler)
+
+	l.Info("Registered Redfish v1 Service Root at %s", r.BasePath())
 }

--- a/internal/controller/http/redfish/v1/root_test.go
+++ b/internal/controller/http/redfish/v1/root_test.go
@@ -1,0 +1,536 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/device-management-toolkit/console/config"
+	"github.com/device-management-toolkit/console/pkg/logger"
+)
+
+const (
+	httpMethodGET = "GET"
+)
+
+func TestGenerateServiceUUID(t *testing.T) {
+	t.Parallel()
+	t.Run("generates valid UUID format", func(t *testing.T) {
+		t.Parallel()
+
+		uuid := generateServiceUUID()
+
+		// Check that UUID is not empty
+		assert.NotEmpty(t, uuid)
+
+		// Check UUID format (8-4-4-4-12 characters)
+		parts := strings.Split(uuid, "-")
+		assert.Len(t, parts, 5, "UUID should have 5 parts separated by dashes")
+		assert.Len(t, parts[0], 8, "First part should be 8 characters")
+		assert.Len(t, parts[1], 4, "Second part should be 4 characters")
+		assert.Len(t, parts[2], 4, "Third part should be 4 characters")
+		assert.Len(t, parts[3], 4, "Fourth part should be 4 characters")
+		assert.Len(t, parts[4], 12, "Fifth part should be 12 characters")
+
+		// Check that version bit is set correctly (4xxx for version 4)
+		assert.True(t, strings.HasPrefix(parts[2], "4"), "UUID should be version 4")
+
+		// Generate multiple UUIDs to ensure they're different
+		uuid2 := generateServiceUUID()
+		assert.NotEqual(t, uuid, uuid2, "Generated UUIDs should be different")
+	})
+}
+
+// TestHealthCheckFunctions tests the health check functions used for 502/503 error conditions
+func TestHealthCheckFunctions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("isDatabaseReachable", func(t *testing.T) {
+		t.Parallel()
+		// Test the database reachability check
+		result := isDatabaseReachable()
+		// Currently always returns true since we use embedded DB
+		assert.True(t, result, "isDatabaseReachable should return true for embedded database")
+	})
+
+	t.Run("areSystemsReachable", func(t *testing.T) {
+		t.Parallel()
+		// Test the systems reachability check
+		result := areSystemsReachable()
+		// Currently always returns true - no external systems required for service root
+		assert.True(t, result, "areSystemsReachable should return true when no external systems are required")
+	})
+
+	t.Run("isExternalServiceHealthy", func(t *testing.T) {
+		t.Parallel()
+		// Test external service health check
+		result := isExternalServiceHealthy()
+		// Currently always returns true - service root is self-contained
+		assert.True(t, result, "isExternalServiceHealthy should return true for self-contained service")
+	})
+
+	t.Run("isServiceOverloaded", func(t *testing.T) {
+		t.Parallel()
+		// Test service overload check
+		result := isServiceOverloaded()
+		// Currently always returns false - no overload detection implemented
+		assert.False(t, result, "isServiceOverloaded should return false when no overload detection is implemented")
+	})
+
+	t.Run("isMaintenanceMode", func(t *testing.T) {
+		t.Parallel()
+		// Test maintenance mode check
+		result := isMaintenanceMode()
+		// Currently always returns false - no maintenance mode implemented
+		assert.False(t, result, "isMaintenanceMode should return false when no maintenance mode is implemented")
+	})
+
+	t.Run("hasResourceExhaustion", func(t *testing.T) {
+		t.Parallel()
+		// Test resource exhaustion check
+		result := hasResourceExhaustion()
+		// Currently always returns false - no resource monitoring implemented
+		assert.False(t, result, "hasResourceExhaustion should return false when no resource monitoring is implemented")
+	})
+}
+
+// Test helper to create a test router with the service root routes
+func createTestRouter(cfg *config.Config) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Create a logger for testing
+	l := logger.New("test")
+
+	// Create a router group for v1 API
+	v1Group := router.Group("/redfish/v1")
+
+	// Register the service root routes
+	NewServiceRootRoutes(v1Group, cfg, l)
+
+	return router
+}
+
+// Test helper to create a test config
+func createTestConfig(authDisabled bool) *config.Config {
+	return &config.Config{
+		Auth: config.Auth{
+			Disabled: authDisabled,
+			JWTKey:   "test-secret-key-for-testing-purposes-only",
+		},
+	}
+}
+
+// TestServiceRootEndpoint tests the main service root endpoint
+func TestServiceRootEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		path           string
+		method         string
+		acceptHeader   string
+		authDisabled   bool
+		expectedStatus int
+		checkResponse  func(t *testing.T, body string, headers http.Header)
+	}{
+		{
+			name:           "successful service root GET",
+			path:           "/redfish/v1/",
+			method:         "GET",
+			acceptHeader:   "application/json",
+			authDisabled:   true,
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body string, headers http.Header) {
+				t.Helper()
+				// Check Redfish headers
+				assert.Equal(t, "4.0", headers.Get("OData-Version"))
+				assert.Equal(t, "application/json; charset=utf-8", headers.Get("Content-Type"))
+				assert.Equal(t, "no-cache", headers.Get("Cache-Control"))
+
+				// Check JSON structure (DMTF v1.11.0 compliant)
+				assert.Contains(t, body, `"@odata.type":"#ServiceRoot.v1_11_0.ServiceRoot"`)
+				assert.Contains(t, body, `"@odata.id":"/redfish/v1/"`)
+				assert.Contains(t, body, `"Id":"RootService"`)
+				assert.Contains(t, body, `"Name":"Redfish Root Service"`)
+				assert.Contains(t, body, `"RedfishVersion":"1.11.0"`)
+				assert.Contains(t, body, `"Systems":{"@odata.id":"/redfish/v1/Systems"}`)
+				assert.Contains(t, body, `"SessionService":{"@odata.id":"/redfish/v1/SessionService"}`)
+				assert.Contains(t, body, `"Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}}`)
+				assert.Contains(t, body, `"Product":"Device Management Toolkit Console"`)
+				assert.Contains(t, body, `"Vendor":"Intel Corporation"`)
+				assert.Contains(t, body, `"UUID":`)
+			},
+		},
+		{
+			name:           "service root with wildcard accept",
+			path:           "/redfish/v1/",
+			method:         "GET",
+			acceptHeader:   "*/*",
+			authDisabled:   true,
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, `"@odata.type":"#ServiceRoot.v1_11_0.ServiceRoot"`)
+			},
+		},
+		{
+			name:           "service root without accept header",
+			path:           "/redfish/v1/",
+			method:         "GET",
+			acceptHeader:   "",
+			authDisabled:   true,
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, `"@odata.type":"#ServiceRoot.v1_11_0.ServiceRoot"`)
+			},
+		},
+		{
+			name:           "service root with unsupported accept header",
+			path:           "/redfish/v1/",
+			method:         "GET",
+			acceptHeader:   "text/xml",
+			authDisabled:   true,
+			expectedStatus: http.StatusNotAcceptable,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, `"Base.1.11.0.NotAcceptable"`)
+				assert.Contains(t, body, "text/xml")
+			},
+		},
+		{
+			name:           "POST method not allowed",
+			path:           "/redfish/v1/",
+			method:         "POST",
+			acceptHeader:   "application/json",
+			authDisabled:   true,
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, headers http.Header) {
+				t.Helper()
+				assert.Equal(t, "GET", headers.Get("Allow"))
+				assert.Contains(t, body, `"Base.1.11.0.OperationNotAllowed"`)
+				assert.Contains(t, body, "POST")
+				assert.Contains(t, body, "ServiceRoot")
+			},
+		},
+		{
+			name:           "PUT method not allowed",
+			path:           "/redfish/v1/",
+			method:         "PUT",
+			acceptHeader:   "application/json",
+			authDisabled:   true,
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, headers http.Header) {
+				t.Helper()
+				assert.Equal(t, "GET", headers.Get("Allow"))
+				assert.Contains(t, body, "PUT")
+				assert.Contains(t, body, "ServiceRoot")
+			},
+		},
+		{
+			name:           "PATCH method not allowed",
+			path:           "/redfish/v1/",
+			method:         "PATCH",
+			acceptHeader:   "application/json",
+			authDisabled:   true,
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, "PATCH")
+			},
+		},
+		{
+			name:           "DELETE method not allowed",
+			path:           "/redfish/v1/",
+			method:         "DELETE",
+			acceptHeader:   "application/json",
+			authDisabled:   true,
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, "DELETE")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := createTestRouter(createTestConfig(tt.authDisabled))
+
+			req, _ := http.NewRequestWithContext(context.Background(), tt.method, tt.path, http.NoBody)
+			if tt.acceptHeader != "" {
+				req.Header.Set("Accept", tt.acceptHeader)
+			}
+
+			if tt.method != httpMethodGET {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if tt.checkResponse != nil {
+				tt.checkResponse(t, w.Body.String(), w.Header())
+			}
+		})
+	}
+}
+
+// TestSessionServiceEndpoints tests SessionService related endpoints
+func TestSessionServiceEndpoints(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		path           string
+		method         string
+		expectedStatus int
+		checkResponse  func(t *testing.T, body string, headers http.Header)
+	}{
+		{
+			name:           "SessionService GET success",
+			path:           "/redfish/v1/SessionService",
+			method:         "GET",
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, `"@odata.type":"#SessionService.v1_0_0.SessionService"`)
+				assert.Contains(t, body, `"@odata.id":"/redfish/v1/SessionService"`)
+				assert.Contains(t, body, `"Id":"SessionService"`)
+				assert.Contains(t, body, `"Name":"Redfish Session Service"`)
+				assert.Contains(t, body, `"ServiceEnabled":true`)
+				assert.Contains(t, body, `"SessionTimeout":30`)
+				assert.Contains(t, body, `"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}`)
+			},
+		},
+		{
+			name:           "Sessions collection GET success",
+			path:           "/redfish/v1/SessionService/Sessions",
+			method:         "GET",
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, `"@odata.type":"#SessionCollection.SessionCollection"`)
+				assert.Contains(t, body, `"@odata.id":"/redfish/v1/SessionService/Sessions"`)
+				assert.Contains(t, body, `"Name":"Session Collection"`)
+				assert.Contains(t, body, `"Members@odata.count":0`)
+				assert.Contains(t, body, `"Members":[]`)
+			},
+		},
+		{
+			name:           "SessionService POST not allowed",
+			path:           "/redfish/v1/SessionService",
+			method:         "POST",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, `"Base.1.11.0.OperationNotAllowed"`)
+				assert.Contains(t, body, "POST")
+				assert.Contains(t, body, "SessionService")
+			},
+		},
+		{
+			name:           "SessionService PUT not allowed",
+			path:           "/redfish/v1/SessionService",
+			method:         "PUT",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, _ http.Header) {
+				t.Helper()
+				assert.Contains(t, body, "PUT")
+			},
+		},
+		{
+			name:           "Sessions collection PUT not allowed",
+			path:           "/redfish/v1/SessionService/Sessions",
+			method:         "PUT",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string, headers http.Header) {
+				t.Helper()
+				assert.Equal(t, "GET, POST", headers.Get("Allow"))
+				assert.Contains(t, body, `"Base.1.11.0.ActionNotSupported"`)
+				assert.Contains(t, body, "retrieve sessions collection")
+				assert.Contains(t, body, "not supported")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := createTestRouter(createTestConfig(true)) // auth disabled
+
+			req, _ := http.NewRequestWithContext(context.Background(), tt.method, tt.path, http.NoBody)
+			if tt.method != httpMethodGET {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if tt.checkResponse != nil {
+				tt.checkResponse(t, w.Body.String(), w.Header())
+			}
+		})
+	}
+}
+
+// TestSystemsCollectionMethods tests Systems collection method restrictions
+func TestSystemsCollectionMethods(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		method         string
+		expectedStatus int
+		checkResponse  func(t *testing.T, body string)
+	}{
+		{
+			name:           "Systems POST not allowed",
+			method:         "POST",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string) {
+				t.Helper()
+				assert.Contains(t, body, "POST")
+				assert.Contains(t, body, "ComputerSystemCollection")
+			},
+		},
+		{
+			name:           "Systems PUT not allowed",
+			method:         "PUT",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string) {
+				t.Helper()
+				assert.Contains(t, body, "PUT")
+				assert.Contains(t, body, "ComputerSystemCollection")
+			},
+		},
+		{
+			name:           "Systems PATCH not allowed",
+			method:         "PATCH",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string) {
+				t.Helper()
+				assert.Contains(t, body, "PATCH")
+				assert.Contains(t, body, "ComputerSystemCollection")
+			},
+		},
+		{
+			name:           "Systems DELETE not allowed",
+			method:         "DELETE",
+			expectedStatus: http.StatusMethodNotAllowed,
+			checkResponse: func(t *testing.T, body string) {
+				t.Helper()
+				assert.Contains(t, body, "DELETE")
+				assert.Contains(t, body, "ComputerSystemCollection")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := createTestRouter(createTestConfig(true))
+
+			req, _ := http.NewRequestWithContext(context.Background(), tt.method, "/redfish/v1/Systems", http.NoBody)
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if tt.checkResponse != nil {
+				tt.checkResponse(t, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestMetadataEndpoint tests the OData $metadata endpoint
+func TestMetadataEndpoint(t *testing.T) {
+	t.Parallel()
+	t.Run("OData metadata XML response", func(t *testing.T) {
+		t.Parallel()
+
+		router := createTestRouter(createTestConfig(true))
+
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", "/redfish/v1/$metadata", http.NoBody)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/xml", w.Header().Get("Content-Type"))
+
+		body := w.Body.String()
+		assert.Contains(t, body, `<?xml version="1.0" encoding="UTF-8"?>`)
+		assert.Contains(t, body, `<edmx:Edmx`)
+		assert.Contains(t, body, `xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"`)
+		assert.Contains(t, body, `Version="4.0"`)
+		assert.Contains(t, body, `<EntityType Name="ServiceRoot">`)
+		assert.Contains(t, body, `<EntityType Name="SessionService">`)
+		assert.Contains(t, body, `<EntityType Name="ComputerSystem">`)
+		assert.Contains(t, body, `<EntityContainer Name="Service">`)
+	})
+}
+
+// TestNewServiceRootRoutes tests the route registration function
+func TestNewServiceRootRoutes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		authDisabled bool
+	}{
+		{
+			name:         "routes with auth disabled",
+			authDisabled: true,
+		},
+		{
+			name:         "routes with auth enabled",
+			authDisabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			l := logger.New("test")
+			cfg := createTestConfig(tt.authDisabled)
+
+			// Create router group
+			v1Group := router.Group("/redfish/v1")
+
+			// This should not panic and should register routes successfully
+			assert.NotPanics(t, func() {
+				NewServiceRootRoutes(v1Group, cfg, l)
+			})
+
+			// Test that routes are actually registered by making a simple request
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "/redfish/v1/", http.NoBody)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// Should get either 200 (auth disabled) or 401 (auth enabled)
+			if tt.authDisabled {
+				assert.Equal(t, http.StatusOK, w.Code)
+			} else {
+				// With auth enabled, should get 401 without proper token
+				assert.Equal(t, http.StatusUnauthorized, w.Code)
+			}
+		})
+	}
+}

--- a/internal/controller/http/router.go
+++ b/internal/controller/http/router.go
@@ -1,4 +1,4 @@
-// Package v1 implements routing paths. Each services in own file.
+// Package http implements routing paths. Each services in own file.
 package http
 
 import (
@@ -16,6 +16,7 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 
 	"github.com/device-management-toolkit/console/config"
+	redfishv1 "github.com/device-management-toolkit/console/internal/controller/http/redfish/v1"
 	v1 "github.com/device-management-toolkit/console/internal/controller/http/v1"
 	v2 "github.com/device-management-toolkit/console/internal/controller/http/v2"
 	"github.com/device-management-toolkit/console/internal/usecase"
@@ -111,6 +112,13 @@ func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases, cfg 
 	h3 := protected.Group("/v2")
 	{
 		v2.NewAmtRoutes(h3, t.Devices, l)
+	}
+
+	// Redfish API v1 routes
+	redfish := handler.Group("/api/redfish/v1")
+	{
+		redfishv1.NewServiceRootRoutes(redfish, cfg, l)
+		redfishv1.NewSystemsRoutes(redfish, t.Devices, l)
 	}
 
 	// Catch-all route to serve index.html for any route not matched above to be handled by Angular

--- a/internal/usecase/sqldb/ieee8021xconfig_test.go
+++ b/internal/usecase/sqldb/ieee8021xconfig_test.go
@@ -67,6 +67,7 @@ func TestIEEE8021xRepo_CheckProfileExists(t *testing.T) {
 				require.NoError(t, err)
 
 				var count int
+
 				err = dbConn.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM ieee8021xconfigs WHERE profile_name = ? AND tenant_id = ?`, "profile1", "tenant1").Scan(&count)
 				require.NoError(t, err)
 				require.Equal(t, 1, count)

--- a/internal/usecase/usecase_test.go
+++ b/internal/usecase/usecase_test.go
@@ -55,6 +55,7 @@ func TestUsecases(t *testing.T) {
 			initializeFunc: func() *Usecases {
 				mockDB := mocks.NewMockSQLDB()
 				mockLogger := mocks.NewMockLogger(nil)
+
 				setupConfig()
 
 				return NewUseCases(mockDB, mockLogger)


### PR DESCRIPTION
Manually tested responses for service root end points listed in OneNote.

- Add complete Redfish service root endpoint (/redfish/v1/) with v1.11.0 compliance
- Implement JWT authentication middleware for Redfish endpoints
- Add comprehensive error handling with Redfish-compliant error responses
- Include SessionService and Sessions collection endpoints
- Add OData $metadata endpoint with XML schema
- Implement health check functions for 502/503 error conditions
- Add proper HTTP method restrictions with 405 responses
- Extract handler functions to reduce cognitive complexity
- Add comprehensive test suite with parallel execution
- Include UUID v4 generation for service identification